### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The resources related to the trustworthiness of large models (LMs) across multip
 
 ## Big love to the community — thank you! 🙏
 
-[![Star History Chart](https://api.star-history.com/svg?repos=CryptoAILab/Awesome-LM-SSP&type=Date)](https://star-history.com/#CryptoAILab/Awesome-LM-SSP&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CryptoAILab/Awesome-LM-SSP&type=Date)](https://star-history.dera.page/#CryptoAILab/Awesome-LM-SSP&Date)
 
 ## Acknowledgement
 


### PR DESCRIPTION
The star history chart at the bottom of the README has stopped loading because the underlying GitHub stargazer API is restricted. This PR points the chart to a working star history service so the community contributions render correctly again.